### PR TITLE
Adding command to getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,7 @@ See some examples in action by cloning the [examples](https://github.com/gamestd
 ```
 git clone https://github.com/gamestdio/colyseus-examples.git
 cd colyseus-examples
+npm run bundle-colyseus-client
 npm install
 ```
 


### PR DESCRIPTION
Adding `npm run bundle-colyseus-client` to getting-started.md. Install doesn't work without it!