### PR TITLE
Update client.md

### DIFF
--- a/docs/client/client.md
+++ b/docs/client/client.md
@@ -394,11 +394,11 @@ client:get_available_rooms("battle", function(err, rooms)
     return
   end
 
-  for i, rooms in pairs(rooms) do
-    print(rooms[i].roomId)
-    print(rooms[i].clients)
-    print(rooms[i].maxClients)
-    print(rooms[i].metadata)
+  for i, room in pairs(rooms) do
+    print(room.roomId)
+    print(room.clients)
+    print(room.maxClients)
+    print(room.metadata)
   end
 end);
 ```


### PR DESCRIPTION
The example lua function for get_available_rooms was not working properly when I tested it. I think the value (rooms) from the key-value pair (i, rooms) replaces the rooms value from the function in the iteration scope. This means that indexing rooms[i] doesnt' work, because "rooms" in the iteration scope is already one individual table (so should probably be called "room").

My proposal is one solution, but you could also do it another way - keep my proposed key-value pair (i, room) but then print rooms[i].roomId. The output should be the same.