### PR TITLE
Fix in docs import colyseus

### DIFF
--- a/docs/client/client.md
+++ b/docs/client/client.md
@@ -18,10 +18,10 @@ The client is used to perform matchmaking calls, and later connect to one or man
 There is no actual server-side connection at this point.
 
 ```typescript fct_label="JavaScript"
-import Colyseus from "colyseus.js";
+import { Client } from "colyseus.js";
 // ...
 
-let client = new Colyseus.Client("ws://localhost:2567");
+let client = new Client("ws://localhost:2567");
 ```
 
 ```csharp fct_label="C#"


### PR DESCRIPTION
import Colyseus from "colyseus.js"
Colyseum - undefined, "export default" not found
Or I don't understand something :#