### PR TITLE
Add info on ArraySchema of primitive types

### DIFF
--- a/docs/best-practices/command-pattern.md
+++ b/docs/best-practices/command-pattern.md
@@ -1,7 +1,7 @@
 **Why?**
 
 - Models ([`@colyseus/schema`](https://github.com/colyseus/schema)) should contain only data, without game logic.
-- Rooms should have a little code as possible, and forward actions to other structures
+- Rooms should have as little code as possible, and forward actions to other structures
 
 **The command pattern has several advantages, such as:**
 

--- a/docs/state/schema.md
+++ b/docs/state/schema.md
@@ -116,6 +116,8 @@ The `ArraySchema` is a synchronizeable version of the built-in JavaScript [Array
 !!! Note "More"
     There are more methods you can use from Arrays. [Have a look at the MDN Documentation for Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/).
 
+#### Array of custom `Schema` type
+
 ```typescript fct_label="TypeScript"
 import { Schema, ArraySchema, type } from "@colyseus/schema";
 
@@ -154,6 +156,36 @@ class MyState extends Schema {
 }
 schema.defineTypes(MyState, {
   blocks: [ Block ],
+});
+```
+
+#### Array of a primitive type
+
+You can't mix types inside arrays.
+
+```typescript fct_label="TypeScript"
+import { Schema, ArraySchema, type } from "@colyseus/schema";
+
+class MyState extends Schema {
+    @type([ "string" ])
+    animals = new ArraySchema<string>();
+}
+```
+
+```typescript fct_label="JavaScript"
+const schema = require('@colyseus/schema');
+const Schema = schema.Schema;
+const ArraySchema = schema.ArraySchema;
+
+class MyState extends Schema {
+    constructor () {
+        super();
+
+        this.animals = new ArraySchema();
+    }
+}
+schema.defineTypes(MyState, {
+  animals: [ "string" ],
 });
 ```
 


### PR DESCRIPTION
I had trouble figuring this out, so adding this to the main docs seems like a good idea to me. The code snippet for Typescript is taken from the official [colyseus/schema repo](https://github.com/colyseus/schema/blob/master/README.md#array-of-a-primitive-type). And the snippet for JavaScript is made up and untested.