### PR TITLE
Update monitor.md

### DIFF
--- a/docs/tools/monitor.md
+++ b/docs/tools/monitor.md
@@ -51,7 +51,7 @@ npm install --save express-basic-auth
 Create a user and password using `express-basic-auth`.
 
 ```typescript
-import * as basicAuth from "express-basic-auth";
+import basicAuth from "express-basic-auth";
 
 const basicAuthMiddleware = basicAuth({
     // list of users and passwords


### PR DESCRIPTION
Using `import * as basicAuth from "express-basic-auth";` causes the following error when you try to call `basicAuth({...})`:

`Type 'typeof expressBasicAuth' has no call signatures.`

This fixes it.