### PR TITLE
Clarified protected connection call

### DIFF
--- a/docs/getting-started/unity3d-client.md
+++ b/docs/getting-started/unity3d-client.md
@@ -68,19 +68,17 @@ The built-in demonstration comes with a single [room handler](https://github.com
 public class ExampleManager : ColyseusManager<ExampleManager>
 ```
 - Make an in-scene manager object to host your custom Manager script.
+- Provide your Manager with a reference to your Colyseus Settings object in the scene inspector.
 
-## Connecting to Your Colyseus Server:
+## Client:
 
-- In order to connect to your server you first need to provide your Manager a reference to your Colyseus Settings object in the scene inspector.
-- Call the `InitializeClient()` method of your Manager to create a `Client` object that will be used to form a connection with the server
-
+- Call the `InitializeClient()` method of your Manager to create a `ColyseusClient` object which is stored in the `client` variable of `ColyseusManager`. This will be used to create/join rooms and form a connection with the server.
 ```csharp
 ExampleManager.Instance.InitializeClient();
 ```
-
--If your Manager has additional classes that need reference to your `Client`, you can override `InitializeClient` and make those connections in there
-
+- If your Manager has additional classes that need reference to your `Client`, you can override `InitializeClient` and make those connections in there.
 ```csharp
+//In ExampleManager.cs
 public override void InitializeClient()
 {
     base.InitializeClient();
@@ -88,10 +86,6 @@ public override void InitializeClient()
     _roomController.SetClient(client);
 }
 ```
-
-## Client:
-
-- When you connect to the server an instance of `ColyseusClient` is created and is stored in the `client` variable of `ColyseusManager`.
 - You can get available rooms on the server by calling `GetAvailableRooms` of `ColyseusClient`:
 ```csharp
 return await GetAvailableRooms<ColyseusRoomAvailable>(roomName, headers);

--- a/docs/getting-started/unity3d-client.md
+++ b/docs/getting-started/unity3d-client.md
@@ -72,10 +72,17 @@ public class ExampleManager : ColyseusManager<ExampleManager>
 ## Connecting to Your Colyseus Server:
 
 - In order to connect to your server you first need to provide your Manager a reference to your Colyseus Settings object in the scene inspector.
-- Call `ConnectToServer()` of your Manager to initiate a server connection:
+- Call `ConnectToServer()` of your Manager to initiate a server connection. If you need to expose this method outside of your manager class, you're welcome to do so:
 
 ```csharp
-ExampleManager.Instance.ConnectToServer();
+//In ExampleManager.cs
+public void BeginServerConnection()
+{
+    ConnectToServer();
+}
+
+//Elsewhere in the project
+ExampleManager.Instance.BeginServerConnection();
 ```
 
 ## Client:

--- a/docs/getting-started/unity3d-client.md
+++ b/docs/getting-started/unity3d-client.md
@@ -72,17 +72,21 @@ public class ExampleManager : ColyseusManager<ExampleManager>
 ## Connecting to Your Colyseus Server:
 
 - In order to connect to your server you first need to provide your Manager a reference to your Colyseus Settings object in the scene inspector.
-- Call `ConnectToServer()` of your Manager to initiate a server connection. If you need to expose this method outside of your manager class, you're welcome to do so:
+- Call the `InitializeClient()` method of your Manager to create a `Client` object that will be used to form a connection with the server
 
 ```csharp
-//In ExampleManager.cs
-public void BeginServerConnection()
-{
-    ConnectToServer();
-}
+ExampleManager.Instance.InitializeClient();
+```
 
-//Elsewhere in the project
-ExampleManager.Instance.BeginServerConnection();
+-If your Manager has additional classes that need reference to your `Client`, you can override `InitializeClient` and make those connections in there
+
+```csharp
+public override void InitializeClient()
+{
+    base.InitializeClient();
+    //Pass the newly created Client reference to our RoomController
+    _roomController.SetClient(client);
+}
 ```
 
 ## Client:

--- a/docs/getting-started/unity3d-client.md
+++ b/docs/getting-started/unity3d-client.md
@@ -175,6 +175,7 @@ room.Send("createEntity", new EntityCreationMessage() { creationId = creationId,
 ```
 
 ### Room State:
+> See how to generate your `RoomState` from [State Handling](https://docs.colyseus.io/state/schema/#client-side-schema-generation)
 - Each room holds its own state. The mutations of the state are synchronized automatically to all connected clients.
 - In regards to room state synchronization:
   - When the user successfully joins the room, they receive the full state from the server.


### PR DESCRIPTION
Fix to community report: https://github.com/colyseus/colyseus-unity3d/issues/147
ConnectToServer is a protected method and therefore cannot be call outside of ExampleManager (or the user's child class)