### PR TITLE
Set required Node version from v12 to v14

### DIFF
--- a/docs/colyseus/index.md
+++ b/docs/colyseus/index.md
@@ -12,7 +12,7 @@ Before we start, let's make sure we have the necessary system requirements insta
 
 **Requirements**:
 
-- [Download and install Node.js](https://nodejs.org/) v12.0 or higher
+- [Download and install Node.js](https://nodejs.org/) v14.0 or higher
 - [Download and install Git SCM](https://git-scm.com/downloads)
 - [Download and install Visual Studio Code](https://code.visualstudio.com/) (or other editor of your choice)
 


### PR DESCRIPTION
v12 gives errors about optional chaining when requiring the library.