### PR TITLE
Add note for onAdd's second param

### DIFF
--- a/docs/state/schema-callbacks.md
+++ b/docs/state/schema-callbacks.md
@@ -186,6 +186,9 @@ The `onAdd` callback is called with the new instance and its key on holder objec
     end)
     ```
 
+!!! Note "Avoiding doubled-up callbacks"
+    You may notice that `onAdd` is called multiple times when an entry is inserted. This is because the "add" callback is called immediately by default for existing items in the collection. When the collection is nested within another schema instance, this can cause doubling. To fix this, set the second argument of `onAdd` to false (e.g. `.onAdd(callback, false)`). See [#147](https://github.com/colyseus/schema/issues/147#issuecomment-1538684941).
+
 ---
 
 #### `onRemove (item, key)`


### PR DESCRIPTION
Related to https://github.com/colyseus/schema/issues/147

Currently, this second param is undocumented, I had to dig through github issues to find the solution for my problem.

This note might not be quite right, it assumes the TypeScript implementation. Do other langs behave the same, do they have the same 2nd param?

The fn signature should probably be mentioned in some way or another. And I think it should be mentioned that `listen()` can have this same problem it seems (causing a `listen -> onAdd` nesting to cause `onAdd` to still trigger multiple times if the data existed before the user joins the room).