### PR TITLE
Tiny grammar fix

### DIFF
--- a/docs/state/index.md
+++ b/docs/state/index.md
@@ -12,7 +12,7 @@ icon: material/sync
 
 </div>
 
-## How state synchronization works?
+## How state synchronization works
 
 - When the client joins a room, it receives the full encoded state from the server.
 - State mutations on the server-side are enqueued at a per-property level. (Only the last mutation of each property is kept)


### PR DESCRIPTION
Hey all, loving the library so far!

Wanted to pass along a small grammar fix from docs — can be either "How state synchronization works" or "How does state synchronization work?", not current "How state synchronization works"

