### PR TITLE
Added x-forwarded-for to nginx proxy headers

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,6 +99,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 86400s;
@@ -125,6 +126,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 86400s;


### PR DESCRIPTION
`request.headers['x-forwarded-for']` should now return player's IP address instead of `undefined`