### PR TITLE
Adding a tip that will avoid new users to waste time

### DIFF
--- a/docs/getting-started/defold-client.md
+++ b/docs/getting-started/defold-client.md
@@ -13,6 +13,8 @@ Open your `game.project` file, and add the following URLs to the `Dependencies` 
     https://github.com/colyseus/colyseus-defold/archive/0.15.zip
     https://github.com/defold/extension-websocket/archive/master.zip
 
+Now, select `Project ▸ Fetch Libraries` to update library dependencies, two folders with the libraries name should pop up on your Defold project. This means the libraries have been imported correctly.
+
 Read more about [Defold library dependencies](http://www.defold.com/manuals/libraries/)
 
 You can also specify a [specific release](https://github.com/colyseus/colyseus-defold/releases) of the SDK, by copying its respective zip archive URL.


### PR DESCRIPTION
Hi I'm new of both Defold and Colyseus, I'd like to add a tip directly on the initial integration tutorial.
Maybe it's because I started learning Colyseus at 10pm on a friday night, but this would have saved me a lot of headaches:

> _Now, select Project ▸ Fetch Libraries to update library dependencies. This happens automatically whenever you open a project so you will only need to do this if the dependencies change without re-opening the project. This happens if you add or remove dependency libraries or if one of the dependency library projects is changed and synchronized by someone._

https://defold.com/manuals/libraries/#setting-up-library-dependencies

I was bashing my head on why it wouldn't find the `/colyseus/client.lua` and nothing on the interweb would help.