### PR TITLE
Fix token type for onAuth room method

### DIFF
--- a/docs/server/room.md
+++ b/docs/server/room.md
@@ -13,7 +13,7 @@ The `Room` class is meant to implement a game session, and/or serve as the commu
 
     export class MyRoom extends Room {
         // (optional) Validate client auth token before joining/creating the room
-        static async onAuth (token: Client, request: http.IncomingMessage) { }
+        static async onAuth (token: string, request: http.IncomingMessage) { }
 
         // When room is initialized
         onCreate (options: any) { }


### PR DESCRIPTION
Change token type to `string` instead of `Client` to match `onAuth` type from `@colyseus/core`