### PR TITLE
docs: fix typo for bunx command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Use the command below to set up a new Colyseus server project:
 
     ``` bash
     # Create a new Colyseus project
-    bunx create-colyseus-app@latest ./my-server
+    bunx create colyseus-app@latest ./my-server
 
     # Enter the project directory
     cd my-server


### PR DESCRIPTION
I fixed a typo that prevented the use of the create command for Bun

*before*
```
$ bunx create-colyseus-app@latest
error: Script not found "create-colyseus-app@latest"
```

*fixed*
```
$ bunx create colyseus-app@latest
× Which template you'd like to use? ·
```