### PR TITLE
Rephrase @filter heading

### DIFF
--- a/pages/upgrading/0.16.mdx
+++ b/pages/upgrading/0.16.mdx
@@ -71,7 +71,7 @@ $(room.state)
 > For more context on why these changes are being applied, see [colyseus/colyseus#709](https://github.com/colyseus/colyseus/issues/709)
 
 
-## `@filter()` and `@filterChildren()` are now deprecated!
+## `@filter()` and `@filterChildren()` are now removed!
 
 The `StateView` feature has been introduced in version 0.16, which allows you to create a view of your state with a subset of the data.
 


### PR DESCRIPTION
The annotations `@filter` and `@filterChildren` were removed in https://github.com/colyseus/schema/commit/b9efdc273a0eec3d2be606a6449a9bb5193b2080, but the upgrade docs use the word "deprecated", which would suggest they're still present but discouraged from being used. The proposed word choice would help users more accurately assess the cost associated with upgrading.