### PR TITLE
Typo: Rename backend update method to fixedTick

### DIFF
--- a/pages/learn/tutorial/phaser/fixed-tickrate.mdx
+++ b/pages/learn/tutorial/phaser/fixed-tickrate.mdx
@@ -173,4 +173,4 @@ onCreate() {
 // (...)
 ```
 
-For consistency, we have also renamed the backend `update()` method to `fixedUpdate()`.
+For consistency, we have also renamed the backend `update()` method to `fixedTick()`.


### PR DESCRIPTION
Fixed typo, the method was renamed to fixedTick and not fixedUpdate.